### PR TITLE
Use podman REST API instead of cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ pip install -r requirements.txt
 source ./env/bin/activate
 ```
 
+You need to activate the podman REST API in a different terminal :
+```bash
+podman system service -t 0
+```
+
 Finally, run the following :
 
 ```bash

--- a/build/elasticsearch/Dockerfile
+++ b/build/elasticsearch/Dockerfile
@@ -1,0 +1,8 @@
+FROM elasticsearch:8.0.1
+
+COPY entrypoint.sh /bin/
+
+USER root
+RUN chmod +x /bin/entrypoint.sh
+
+ENTRYPOINT ["/bin/entrypoint.sh"]

--- a/build/elasticsearch/entrypoint.sh
+++ b/build/elasticsearch/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+/usr/share/elasticsearch/bin/elasticsearch-certutil ca --pass "" --out /shared/cert/elastic-stack-ca.p12
+
+/usr/share/elasticsearch/bin/elasticsearch-certutil cert --ca-pass "" --pass "" --ca /shared/cert/elastic-stack-ca.p12 --out /shared/cert/elastic-certificates.p12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,11 @@
+certifi==2021.10.8
+charset-normalizer==2.0.12
+idna==3.3
 Jinja2==3.0.3
 MarkupSafe==2.1.0
+podman-py==3.1.2.1
+pyxdg==0.27
 PyYAML==6.0
+requests==2.27.1
+toml==0.10.2
+urllib3==1.24.3

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 from jinja2 import Template
+from podman import PodmanClient
 import shlex, subprocess
 import yaml
 import os
@@ -30,43 +31,83 @@ def execute(cmd):
     return proc.communicate()
 
 
-def deploy_pod():
-    cmd = "podman pod create --name sparassidae --publish 5601:5601 --publish 9200:9200 --publish 5140:5140"
-    execute(cmd)
+def deploy_pod(socket, conf):
 
-def create_es_certificates():
+    portmappings = [
+            {
+                "container_port": port,
+                "host_ip": "0.0.0.0",
+                "host_port": port,
+                "protocol": "tcp"
+            } for port in conf["expose"]
+        ]
+
+    with PodmanClient(base_url=socket) as client:
+        response = client.pods.create(conf["name"], portmappings=portmappings)
+
+    return response
+
+def create_es_certificates(url):
 
     if not os.path.exists("elasticsearch/cert/elastic-certificates.p12"):
         os.makedirs("elasticsearch/cert", exist_ok=True)
 
-        cmd = "podman run -it --rm -v $(pwd)/elasticsearch/cert:/shared/cert elasticsearch /bin/bash"
-        os.system(cmd)
-        os.system("chmod 644 ./elasticsearch/cert/elastic-certificates.p12")
+        params = {
+            "container": {
+                "image": "elasticsearch-sparassidae",
+                "tag": "latest"
+            },
+            "volumes": [
+                {
+                    "path": os.path.abspath("elasticsearch/cert"),
+                    "mountPath": "/shared/cert",
+                    "mode": "rw"
+                }
+            ],            
+            "auto_remove": True
+        }
+
+        deploy_container(url, params, 'elastic-certs')
 
 
-def deploy_container(conf, cots):
-    
-    cmd = f"podman run --pod sparassidae --name sparassidae.{cots} -d "
+def deploy_container(url, conf, name):
 
-    if "env" in conf[cots].keys():
-        for env in conf[cots]["env"]:
-            cmd += f'-e "{env["name"]}={env["value"]}" '
+    image_name = f'{conf["container"]["image"]}:{conf["container"]["tag"]}'
 
-    if "volumes" in conf[cots].keys():
-        for vol in conf[cots]["volumes"]:
-            
-            if not os.path.exists(vol["path"]):
-                os.makedirs(vol["path"], exist_ok=True)
+    env = {var["name"]:var["value"] for var in conf["env"]} if "env" in conf.keys() else {}
 
-            if vol["path"].startswith('/'):
-                cmd += f'-v {vol["path"]}:{vol["mountPath"]} '
-            else:
-                cmd += f'-v $(pwd)/{vol["path"]}:{vol["mountPath"]} '
+    mounts = [
+        {
+            "target": vol["mountPath"],
+            "source": os.path.abspath(vol["path"]),
+            "type": "bind"
+        } for vol in conf["volumes"]
+    ]
 
-    cmd += f'{conf[cots]["container"]["image"]}:{conf[cots]["container"]["tag"]} '
+    for vol in conf["volumes"]:
+        if not os.path.exists(vol["path"]):
+            os.makedirs(vol["path"], exist_ok=True)
 
-    if "command_line" in conf[cots].keys():
-        cmd += conf[cots]["command_line"]
+    command = conf["command_line"].split(" ") if "command_line" in conf.keys() else []
 
-    os.system(cmd)
+    entrypoint = conf["entrypoint"] if "entrypoint" in conf.keys() else []
+
+    auto_remove = conf["auto_remove"] if "auto_remove" in conf.keys() else False
+
+    with PodmanClient(base_url=url) as client:
+        image = client.images.get(image_name)
+        response = client.containers.create(
+            image,
+            pod="sparassidae",
+            name=name,
+            environment=env,
+            mounts=mounts,
+            command=command,
+            entrypoint=entrypoint,
+            auto_remove=auto_remove
+        )
+
+        response.start()
+
+    return response
 

--- a/values.yaml
+++ b/values.yaml
@@ -1,71 +1,89 @@
 
-elasticsearch:
-  enabled: true
-  container: 
-    image: elasticsearch
-    tag: 8.0.1
-  host: localhost
-  port: 9200
-  scheme: https
-  config:
-    filename: elasticsearch.yml
-  env:
-    - name: discovery.type
-      value: single-node
-    - name: ELASTIC_PASSWORD
-      value: changeme
-  volumes:
-    - path: elasticsearch/conf/elasticsearch.yml
-      mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
-    - path: elasticsearch/cert/elastic-certificates.p12
-      mountPath: /usr/share/elasticsearch/config/elastic-certificates.p12
+pod:
+  name: "sparassidae"
+  expose:
+    - 9200
+    - 5601
+    - 5140
 
-kibana:
-  enabled: true
-  container:
-    image: kibana
-    tag: 8.0.1
-  user: kibana_system
-  pass: changeme
-  config:
-    filename: kibana.yml
-  volumes:
-    - path: kibana/conf/kibana.yml
-      mountPath: /usr/share/kibana/config/kibana.yml
+containers:
+  elasticsearch:
+    enabled: true
+    container: 
+      image: elasticsearch
+      tag: 8.0.1
+    host: localhost
+    port: 9200
+    scheme: https
+    config:
+      filename: elasticsearch.yml
+    env:
+      - name: discovery.type
+        value: single-node
+      - name: ELASTIC_PASSWORD
+        value: changeme
+    volumes:
+      - path: elasticsearch/conf/elasticsearch.yml
+        mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
+        mode: "r"
+      - path: elasticsearch/cert/elastic-certificates.p12
+        mountPath: /usr/share/elasticsearch/config/elastic-certificates.p12
+        mode: "r"
 
-elastalert2:
-  enabled: true
-  container:
-    image: jertel/elastalert2
-    tag: latest
-  user: elastic
-  pass: changeme
-  config:
-    filename: config.yaml
-  volumes:
-    - path: elastalert2/enhancements
-      mountPath: /opt/elastalert/enhancements
-    - path: elastalert2/certs
-      mountPath: /opt/elastalert/certs
-    - path: elastalert2/rules
-      mountPath: /opt/elastalert/rules
-    - path: elastalert2/conf/config.yaml
-      mountPath: /opt/elastalert/config.yaml
+  kibana:
+    enabled: true
+    container:
+      image: kibana
+      tag: 8.0.1
+    user: kibana_system
+    pass: changeme
+    config:
+      filename: kibana.yml
+    volumes:
+      - path: kibana/conf/kibana.yml
+        mountPath: /usr/share/kibana/config/kibana.yml
+        mode: "r"
 
-fluentd:
-  enabled: true
-  container:
-    image: fluentd-sparassidae
-    tag: latest
-  user: elastic
-  pass: changeme
-  command_line: -c /fluentd/etc/fluent.conf
-  config:
-    filename: fluent.conf
-  volumes:
-    - path: /var/log/audit
-      mountPath: /shared/data
-    - path: dataset
-      mountPath: /shared/dataset
-    - path: fluentd/conf
-      mountPath: /fluentd/etc
+  elastalert2:
+    enabled: true
+    container:
+      image: jertel/elastalert2
+      tag: latest
+    user: elastic
+    pass: changeme
+    config:
+      filename: config.yaml
+    volumes:
+      - path: elastalert2/enhancements
+        mountPath: /opt/elastalert/enhancements
+        mode: "r"
+      - path: elastalert2/certs
+        mountPath: /opt/elastalert/certs
+        mode: "r"
+      - path: elastalert2/rules
+        mountPath: /opt/elastalert/rules
+        mode: "r"
+      - path: elastalert2/conf/config.yaml
+        mountPath: /opt/elastalert/config.yaml
+        mode: "r"
+
+  fluentd:
+    enabled: true
+    container:
+      image: fluentd-sparassidae
+      tag: latest
+    user: elastic
+    pass: changeme
+    command_line: -c /fluentd/etc/fluent.conf
+    config:
+      filename: fluent.conf
+    volumes:
+      - path: /var/log/audit
+        mountPath: /shared/data
+        mode: "rw"
+      - path: dataset
+        mountPath: /shared/dataset
+        mode: "rw"
+      - path: fluentd/conf
+        mountPath: /fluentd/etc
+        mode: "r"


### PR DESCRIPTION
It is better to use the available API than crafting the cmds and using the subprocess library.

In addition, I automated the creation of ES certs.